### PR TITLE
increased maxVersion to 4.1

### DIFF
--- a/install.rdf
+++ b/install.rdf
@@ -30,7 +30,7 @@
 			<Description>
 				<em:id>{ec8030f7-c20a-464f-9b0e-13a3a9e97384}</em:id> <!-- firefox -->
 				<em:minVersion>4.0b7</em:minVersion>
-				<em:maxVersion>4.0b9pre</em:maxVersion>
+				<em:maxVersion>4.1</em:maxVersion>
 			</Description>
 		</em:targetApplication>
 


### PR DESCRIPTION
Firefox 4.0.1 was released, so Barlesque no longer works without either changing the version in install.rdf or hacking it in about:config. This patches install.rdf and jumps to maxVersion 4.1 because minor-minor version increases aren't likely to break Barlesque. A more reasonable patch would be to set maxVersion to 4.0.1.
