### PR TITLE
14x14 is too small and totally obscured by the 'resize window' widget on 

### DIFF
--- a/chrome/skin/overlay.css
+++ b/chrome/skin/overlay.css
@@ -115,8 +115,8 @@
 
 #barlesque-collapser
 {
-	width: 14px;
-	height: 14px;
+	width: 18px;
+	height: 18px;
 
 	position: absolute;
 	bottom: 0px;


### PR DESCRIPTION
14x14 is too small and totally obscured by the 'resize window' widget on OS X, so increase to 18x18.
